### PR TITLE
Enhancements using gcalendar 0.4.1

### DIFF
--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/lib/eventview.js
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/lib/eventview.js
@@ -1,0 +1,176 @@
+#!/usr/bin/cjs
+
+imports.gi.versions.Gtk = '3.0';
+
+const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
+const Gtk = imports.gi.Gtk;
+const WebKit =  imports.gi.WebKit2;
+const Gettext = imports.gettext;
+
+const app = new Gtk.Application({ application_id: 'gcalendar.eventdisplay' });
+
+const UUID_GCALENDAR = "googleCalendar@javahelps.com";
+Gettext.bindtextdomain(UUID_GCALENDAR, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(str) {
+    return Gettext.dgettext(UUID_GCALENDAR, str);
+}
+
+
+function getStdIn() {
+  const stdinStream = new Gio.DataInputStream({
+    base_stream: new Gio.UnixInputStream({ fd: 0}),
+  });
+
+  let buf = '';
+  while ( [str, len] = stdinStream.read_line_utf8(null) ) {
+    if (len < 1) {
+      break;
+      }
+      buf += str + '\n';
+  }
+  return buf;
+}
+
+function getStatusStr( respStat ) {
+  let retStr = '';
+  
+    if (respStat=='needsAction') {
+      retStr += '\u2610';
+    }
+
+    if (respStat=='confirmed') {
+      retStr += '\u2611\ufe0f';
+    }
+
+    if (respStat=='accepted') {
+      retStr += '\u2611';
+    }
+
+    if (respStat=='rejected') {
+      retStr += '\u2718';
+    }
+
+    if (respStat=='tentative') {
+      retStr += '\u2370';
+    }
+
+  return retStr;  
+}
+
+function getNameStr(orgObj, subject ='') {
+  let retStr = '';
+  
+  if (orgObj.hasOwnProperty('responseStatus')) {
+    retStr += getStatusStr(orgObj.responseStatus) + ' - ';
+  }
+  
+  let displayName = 'unknown';
+  
+  if (orgObj.hasOwnProperty('displayName') && orgObj) {
+    displayName = orgObj['displayName'];
+  } 
+  if (orgObj.hasOwnProperty('email')) {
+    if  (displayName=='unknown') {
+      displayName = orgObj.email;
+    }
+    retStr += '<a target="_blank" href="mailto:' + orgObj['email'] + '?subject=' +  encodeURIComponent('Re: ' + subject) + '">' + displayName + '</a>';
+  } else {
+    retStr += displayName;
+  }
+  
+  return retStr;
+}
+
+app.connect('activate', () => {
+  const window = new Gtk.ApplicationWindow({ application: app });
+  window.set_title('Event: ' + event_title);
+  
+  let sizex = GLib.getenv('GCAL_EVENTVIEW_SIZEX') ?? 800;
+  let sizey = GLib.getenv('GCAL_EVENTVIEW_SIZEY') ?? 600;
+  
+  window.set_default_size(sizex, sizey);
+  
+  const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+
+  const buttonBox = new Gtk.ButtonBox({ orientation: Gtk.Orientation.VERTICAL, layout_style: Gtk.ButtonBoxStyle.EXPAND });
+  const buttonClose = new Gtk.Button({ label: 'Close'});
+  buttonClose.connect('clicked', () => {
+    app.quit();
+  } );
+  
+  buttonBox.add(buttonClose);
+
+  const webView = new WebKit.WebView({expand: true});
+  webView.get_settings().set_enable_javascript(false);
+  webView.load_html(event_body,null);
+  webView.connect('decide-policy', (view, decision, type) => {
+
+    if ( type == WebKit.PolicyDecisionType.NAVIGATION_ACTION  || type == WebKit.PolicyDecisionType.NEW_WINDOW_ACTION ) {
+    
+      let uri = decision.get_navigation_action().get_request().get_uri(); 
+    
+      if (uri=='about:blank') {
+        return false;
+      }
+      
+      console.log('CallingURI: ', uri);
+      
+      let [spwnsuccess, argv] = GLib.shell_parse_argv("xdg-open '"+uri+"'");
+      let spawn_flags = GLib.SpawnFlags.SEARCH_PATH
+                      | GLib.SpawnFlags.STDOUT_TO_DEV_NULL
+                      | GLib.SpawnFlags.STDERR_TO_DEV_NULL;
+      let [success, pid] = GLib.spawn_async(null, argv, null, spawn_flags, null);
+      
+      decision.ignore();
+      return true;
+    }
+    
+    decision.ignore();
+    return true;
+  } );
+  
+  box.add(buttonBox);
+  box.add(webView);
+  window.add(box);
+
+  window.show_all();
+});
+
+const inJSON = JSON.parse( getStdIn() ) ;
+
+const event_description = inJSON.description ?? '';
+const event_title	  = inJSON.name ?? inJSON.summary ?? '';
+const event_status	  = inJSON.status ?? '';
+const event_location      = inJSON.location ?? '';  
+const event_organizer	  = inJSON.organizer ?? {};            
+const event_attendees	  = inJSON.attendees ?? [];
+
+const startDate = new Date(Date.parse(inJSON.startDate ?? ''));
+const endDate   = new Date(Date.parse(inJSON.endDate ?? ''));
+
+const LCTIME = GLib.getenv('LC_TIME').replace(/_/gm, '-').replace(/\..*/gm, '');
+
+const event_start = startDate.toLocaleDateString(LCTIME) + ' ' + ( inJSON.startTime ?? '' );
+const event_end   = endDate.toLocaleDateString(LCTIME) + ' ' + ( inJSON.endTime ?? '');
+
+
+event_body = 
+  '<table style="background: #D0D0F0; padding: 5px;" width="100%" border="1px">' +
+    '<tr><td colspan="2"><h1>' + getStatusStr(event_status) + ' - '  + event_title + '<h1></td></tr>' +
+    '<tr><td colspan="2"><h2>[ ' + event_start + ' ... ' + event_end + ' ]</h2></td></tr>' +
+    '<tr><td><h3>' + _('Location') + '</h3></td><td><h2>' + event_location + '</h2></td></tr>' +
+    '<tr><td><h3>' + _('Organizer') + '</h3></td><td>' + getNameStr(event_organizer, event_title + ' - ' + event_start) + '</td></tr>' +
+    '<tr><td><h3>' + _('Attendees') + '</h3></td><td>' 
+    ;
+
+if (typeof event_attendees != 'string') {
+  event_attendees.forEach( item =>  {
+    event_body += getNameStr(item, event_title + ' ' + event_start)+ ',<br> ';
+  });   
+}
+event_body += '</td></tr></table>'; 
+event_body += event_description;
+
+app.run([]);

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/googleCalendar.pot
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/googleCalendar.pot
@@ -422,3 +422,38 @@ msgstr ""
 #. settings-schema.json->cornerradius->tooltip
 msgid "Radius for rounding the desklet's corners"
 msgstr ""
+
+
+#. settings
+msgid "Show event details in tooltip"
+msgstr ""
+
+#. settings
+msgid "Show event details on clicking the event"
+msgstr ""
+
+#. settings
+msgid "Width of detail windows"
+msgstr ""
+
+#. settings
+msgid "Height of detail windows"
+msgstr ""
+
+#. settings
+msgid "Show confirmation state on event list"
+msgstr ""
+
+
+#:lib/eventview.js
+msgid "Location"
+msgstr ""
+
+#:lib/eventview.js
+msgid "Organizer"
+msgstr ""
+
+#:lib/eventview.js
+msgid "Attendees"
+msgstr ""
+

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/hu.po
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/po/hu.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-11-14 20:26-0500\n"
-"PO-Revision-Date: 2021-12-06 10:34+0100\n"
+"PO-Revision-Date: 2024-04-07 21:58+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. metadata.json->name
 #. settings-schema.json->page_gcalendar->title
@@ -346,11 +346,11 @@ msgstr "Holnapi nap formátumának megadása itt"
 
 #. settings-schema.json->use_24h_clock->description
 msgid "Use 24h clock"
-msgstr "24 órás formátum használata"
+msgstr "24 órás időformátum használata"
 
 #. settings-schema.json->use_24h_clock->tooltip
 msgid "Check to show time in 24h"
-msgstr "Jelölje be ezt a 24 órás formátum megjelenítéséhez"
+msgstr "Jelölje be ezt a 24 órás időformátum megjelenítéséhez"
 
 #. settings-schema.json->zoom->units
 msgid "times"
@@ -432,3 +432,32 @@ msgstr "Sarok sugara"
 #. settings-schema.json->cornerradius->tooltip
 msgid "Radius for rounding the desklet's corners"
 msgstr "Az asztalkalmazás sarkainak lekerekítése során használt sugár"
+
+#. settings
+msgid "Show event details in tooltip"
+msgstr "Eseményrészletek mutatása az ablak tippekben"
+
+#. settings
+msgid "Show event details on clicking the event"
+msgstr "Eseményrészletek mutatása az eseményre kattintáskor"
+
+#. settings
+msgid "Width of detail windows"
+msgstr "Az eseményrészletek ablak szélessége"
+
+#. settings
+msgid "Height of detail windows"
+msgstr "Az eseményrészletek ablak magassága"
+
+#. settings
+msgid "Show confirmation state on event list"
+msgstr "Részvételi állapot mutatása az eseménylistában"
+
+msgid "Location"
+msgstr "Helyszín"
+
+msgid "Organizer"
+msgstr "Szerverző"
+
+msgid "Attendees"
+msgstr "Résztvevők"

--- a/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/settings-schema.json
+++ b/googleCalendar@javahelps.com/files/googleCalendar@javahelps.com/settings-schema.json
@@ -51,6 +51,11 @@
         "diff_calendar",
         "show_location",
         "location_color",
+        "show_tooltip",
+        "show_details",
+        "show_state",
+        "detail_sizex", 
+        "detail_sizey",
         "cornerradius"
       ]
     }
@@ -212,6 +217,44 @@
     "default": "rgb(255,255,255)",
     "description": "Location text color",
     "tooltip": "Click the button to select a new location text color"
+  },
+  "show_tooltip": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show event details in tooltip",
+    "tooltip": "Show event information in tooltip"
+  },
+  "show_details": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show event details on clicking the event",
+    "tooltip": "Show event information by clicking"
+  },
+  "show_state": {
+    "type": "checkbox",
+    "default": true,
+    "description": "Show confirmation state on event list",
+    "tooltip": "Show confirmation"
+  },
+  "detail_sizex": {
+    "type": "scale", 
+    "indent": true,
+    "default": 400,
+    "min": 200,
+    "max": 2000,
+    "step": 10,
+    "description": "Width of detail windows",
+    "tooltip": "Set X size of detial windows."
+  },
+  "detail_sizey": {
+    "type": "scale", 
+    "indent": true,
+    "default": 600,
+    "min": 200,
+    "max": 2000,
+    "step": 10,
+    "description": "Height of detail windows",
+    "tooltip": "Set Y size of detial windows."
   },
   "cornerradius": {
     "type": "spinbutton",


### PR DESCRIPTION
Please check and consider to push over to main cinnamon repo if you find these changes valuable. 

These enhancements are using the features were added to [gcalendar 0.4.1 Pull request Ref#20]( https://github.com/slgobinath/gcalendar/pull/20 )

To list the main changes (both can be switched off in settings):
- Eventviewer window to pop up by clicking on the event description 
- Tooltip popup by hovering on the event
- Confirmation status (eg: confirmed, cancelled, tentative...) on event list 

The changes are comply to gcalendar 0.4 however to use the new features update required to latest - 0.4.1 
   `pip install gcalendar -u`
